### PR TITLE
Add caching to limit DB calls inside EntityFrameworkCargoDataSources

### DIFF
--- a/Cargo.EntityFramework/Cargo.EntityFramework.csproj
+++ b/Cargo.EntityFramework/Cargo.EntityFramework.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CargoEntityFrameworkExtensions.cs" />
+    <Compile Include="ContentCache.cs" />
     <Compile Include="EntityFrameworkCargoDataSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Cargo.EntityFramework/ContentCache.cs
+++ b/Cargo.EntityFramework/ContentCache.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Cargo
+{
+    /// <summary>
+    /// Used to cache content inside cargo
+    /// </summary>
+    public sealed class ContentCache
+    {
+        private static volatile ContentCache instance;
+        private static object syncRoot = new Object();
+
+        /// <summary>
+        /// Items cached
+        /// </summary>
+        public List<ContentItem> ContentItems { get { return contentItems;  } }
+        private List<ContentItem> contentItems;
+
+        private ContentCache() { }
+
+
+        /// <summary>
+        /// Since we only want one cache per application. Singleton pattern implementation chosen.
+        /// </summary>
+        public static ContentCache Instance
+        {
+            get
+            { 
+                if (instance == null)
+                {
+                    lock (syncRoot)
+                    {
+                        if (instance == null)
+                        {
+                            instance = new ContentCache();
+                        }
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+
+        /// <summary>
+        /// Init the content items for the cache
+        /// </summary>
+        public static void InitContentItems(List<ContentItem> items)
+        {
+            lock (syncRoot)
+            {
+                if (instance != null)
+                { 
+                    instance.contentItems = items;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove an item from the cache
+        /// </summary>
+        /// <param name="item">Item to remove</param>
+        public void RemoveItem(ContentItem item)
+        {
+            lock (syncRoot)
+            {
+                instance.contentItems.Remove(item);
+            }
+        }
+
+        /// <summary>
+        /// Add an item from the cache
+        /// </summary>
+        /// <param name="item">Item to add</param>
+        public void AddItem(ContentItem item)
+        {
+            lock (syncRoot)
+            {
+                //Be safe, we do not know where other threads are in this method
+                if (!instance.contentItems.Contains(item))
+                {
+                    instance.contentItems.Add(item);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Find a item and update it
+        /// </summary>
+        /// <param name="item">Item to update</param>
+        public void UpdateItem(ContentItem item)
+        {
+            lock (syncRoot)
+            {
+                var cachedItem = instance.contentItems
+                                         .Find( x => x.Key.Equals(item.Key) && x.Location.Equals(item.Location));
+
+                if (cachedItem != null)
+                {
+                    cachedItem.Content = item.Content;
+                    cachedItem.OriginalContent = item.OriginalContent;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Find a item and update its content
+        /// </summary>
+        /// <param name="item">Item to update</param>
+        public void UpdateItemContent(ContentItem item)
+        {
+            lock (syncRoot)
+            {
+                var cachedItem = instance.contentItems
+                                         .Find(x => x.Key.Equals(item.Key) && x.Location.Equals(item.Location));
+
+                if (cachedItem != null)
+                {
+                    cachedItem.Content = item.Content;
+                }
+            }
+        }
+
+    }
+}

--- a/CargoExample/MyDataContext.cs
+++ b/CargoExample/MyDataContext.cs
@@ -7,8 +7,13 @@ using Cargo;
 
 namespace CargoExample
 {
-    public class MyDataContext : DbContext
+    public class MyDataContext : DbContext 
     {
+        public MyDataContext() : base("name=DefaultConnection")
+        {
+
+        }
+
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             modelBuilder.MapCargoContent();

--- a/CargoExample/Web.config
+++ b/CargoExample/Web.config
@@ -9,7 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-CargoExample-20150728122646.mdf;Initial Catalog=aspnet-CargoExample-20150728122646;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=.;Initial Catalog=CargoExample;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
@@ -72,11 +72,7 @@
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="mssqllocaldb" />
-      </parameters>
-    </defaultConnectionFactory>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>


### PR DESCRIPTION
I've add Caching using a newly created ContentCache class; using it inside EntityFrameworkCargoDataSource. 

The web config has been changed to run a trace more easily. The effect looks promising, but please do tell if you want an alternative approach (I'm sure there are plenty) or notice possible issues.